### PR TITLE
Implement module seeding and trial cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "nestjs-prisma": "^0.25.0",
     "prisma": "^6.12.0",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@nestjs/schedule": "^3.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/module.service.ts
+++ b/src/module.service.ts
@@ -1,0 +1,51 @@
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { ModuleEnum } from '@prisma/client';
+import { CustomPrismaService } from 'nestjs-prisma';
+
+@Injectable()
+export class ModuleService implements OnModuleInit {
+  constructor(
+    @Inject('PrismaService')
+    private readonly prisma: CustomPrismaService
+  ) {}
+
+  async onModuleInit() {
+    await this.seedModules();
+  }
+
+  private async seedModules() {
+    const moduleNames = Object.values(ModuleEnum);
+    for (const name of moduleNames) {
+      await this.prisma.client.module.upsert({
+        where: { name },
+        create: { name },
+        update: {},
+      });
+    }
+  }
+
+  async enableAllModulesForTenant(tenantId: string) {
+    const modules = await this.prisma.client.module.findMany();
+    for (const mod of modules) {
+      await this.prisma.client.enabledModule.upsert({
+        where: {
+          tenantId_moduleName: {
+            tenantId,
+            moduleName: mod.name,
+          },
+        },
+        create: {
+          tenantId,
+          moduleName: mod.name,
+        },
+        update: {},
+      });
+    }
+  }
+
+  async disableAllModulesForTenant(tenantId: string) {
+    await this.prisma.client.enabledModule.deleteMany({
+      where: { tenantId },
+    });
+  }
+}

--- a/src/tenant.module.ts
+++ b/src/tenant.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TenantService } from './tenant.service';
 import { TenantController } from './tenant.controller';
 import { TenantRepository } from './tenant.repository';
 import { CustomPrismaModule } from 'nestjs-prisma';
 import { extendedPrismaClient } from 'prisma/prisma.extension';
+import { ModuleService } from './module.service';
+import { TrialExpirationService } from './trial-expiration.service';
 
 @Module({
   imports: [
@@ -14,8 +17,14 @@ import { extendedPrismaClient } from 'prisma/prisma.extension';
       },
       isGlobal: true,
     }),
+    ScheduleModule.forRoot(),
   ],
   controllers: [TenantController],
-  providers: [TenantService, TenantRepository],
+  providers: [
+    TenantService,
+    TenantRepository,
+    ModuleService,
+    TrialExpirationService,
+  ],
 })
 export class TenantModule {}

--- a/src/tenant.service.ts
+++ b/src/tenant.service.ts
@@ -1,11 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Payload } from '@nestjs/microservices/decorators/payload.decorator';
 import { EventPattern, MessagePattern } from '@nestjs/microservices';
 import { TenantRepository } from './tenant.repository';
+import { ModuleService } from './module.service';
 
 @Injectable()
 export class TenantService {
-  constructor(private readonly tenantRepository: TenantRepository) {}
+  constructor(
+    private readonly tenantRepository: TenantRepository,
+    private readonly moduleService: ModuleService
+  ) {}
 
   create(createTenantDto: { companyName: string; slug: string }) {
     return this.tenantRepository.create(createTenantDto);
@@ -23,10 +27,12 @@ export class TenantService {
     return `This action removes a #${id} tenant`;
   }
 
-  createTenant(
+  async createTenant(
     @Payload() createTenantDto: { companyName: string; slug: string }
   ) {
     console.log('Creating tenant with data:', createTenantDto);
-    return this.tenantRepository.create(createTenantDto);
+    const tenant = await this.tenantRepository.create(createTenantDto);
+    await this.moduleService.enableAllModulesForTenant(tenant.tenantId);
+    return tenant;
   }
 }

--- a/src/trial-expiration.service.ts
+++ b/src/trial-expiration.service.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { ModuleService } from './module.service';
+
+@Injectable()
+export class TrialExpirationService {
+  private readonly logger = new Logger(TrialExpirationService.name);
+
+  constructor(
+    @Inject('PrismaService')
+    private readonly prisma: CustomPrismaService,
+    private readonly moduleService: ModuleService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleCron() {
+    const expiredTenants = await this.prisma.client.tenant.findMany({
+      where: {
+        status: 'TRIAL',
+        trialEndsAt: { lte: new Date() },
+      },
+    });
+
+    for (const tenant of expiredTenants) {
+      this.logger.log(`Disabling modules for tenant ${tenant.tenantId}`);
+      await this.moduleService.disableAllModulesForTenant(tenant.tenantId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- predefine modules via new `ModuleService`
- enable modules for new tenants
- schedule cron job to disable modules after trials end
- wire up the new services in `TenantModule`
- include `@nestjs/schedule` dependency

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c0878fe0832b988f1c1ed0016b64