### PR TITLE
Fix tenant module fetching

### DIFF
--- a/src/dto/tenant-entity.dto.ts
+++ b/src/dto/tenant-entity.dto.ts
@@ -57,5 +57,5 @@ export class TenantDto {
 
   @Expose()
   @Type(() => EnabledModuleDto)
-  enabledModules: EnabledModuleDto; // Assuming this is an array of enabled modules
+  enabledModules: EnabledModuleDto[];
 }

--- a/src/tenant.repository.ts
+++ b/src/tenant.repository.ts
@@ -35,7 +35,11 @@ export class TenantRepository {
     const tenant = await this.prismaService.client.tenant.findUnique({
       where: { tenantId },
       include: {
-        enabledModules: true,
+        enabledModules: {
+          select: {
+            moduleName: true,
+          },
+        },
       },
     });
     if (!tenant) {

--- a/src/tenant.service.ts
+++ b/src/tenant.service.ts
@@ -12,9 +12,9 @@ export class TenantService {
     private readonly moduleService: ModuleService
   ) {}
 
-  findOne(tenantId: string): Promise<TenantDto> {
-    const tenant = this.tenantRepository.findById(tenantId);
-    return tenant;
+  async findOne(tenantId: string): Promise<TenantDto> {
+    const tenant = await this.tenantRepository.findById(tenantId);
+    return tenant as TenantDto;
   }
 
   async createTenant(createTenantDto: { companyName: string; slug: string }) {


### PR DESCRIPTION
## Summary
- include only module names when retrieving a tenant
- await repository call in tenant service
- fix DTO to allow array of enabled modules

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888fe27a7e4832b9829faeda3c2d7f4