### PR TITLE
Implement Stripe webhook handling

### DIFF
--- a/src/billing/billing.utils.ts
+++ b/src/billing/billing.utils.ts
@@ -1,5 +1,5 @@
-type ModuleName = 'INSIGHT' | 'FLOW' | 'ACCESS';
-type UserTier = 'CORE' | 'TEAM' | 'PRO' | 'ENTERPRISE';
+export type ModuleName = 'INSIGHT' | 'FLOW' | 'ACCESS';
+export type UserTier = 'CORE' | 'TEAM' | 'PRO' | 'ENTERPRISE';
 
 const modulePrices: Record<ModuleName, number> = {
   // pro Module
@@ -17,7 +17,7 @@ const userPrices: Record<UserTier, number> = {
 
 const setupFee = 49;
 
-function calculateOrderLinkPricing(
+export function calculateOrderLinkPricing(
   modules: ModuleName[],
   userTier: UserTier
 ): {

--- a/src/billing/dto/create-checkout-session.dto.ts
+++ b/src/billing/dto/create-checkout-session.dto.ts
@@ -1,3 +1,5 @@
+import { ModuleName, UserTier } from '../billing.utils';
+
 export class CreateCheckoutSessionDto {
   modules: ModuleName[];
   userTier: UserTier;


### PR DESCRIPTION
## Summary
- export types and pricing helper
- use pricing helper in billing service
- handle stripe webhook events in billing service
- simplify billing controller

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b584b1ea0832b9647d56267daded4