### PR TITLE
Implement Stripe webhook handling

### DIFF
--- a/src/billing/billing.controller.ts
+++ b/src/billing/billing.controller.ts
@@ -1,8 +1,8 @@
-import { Body, Controller, Post, RawBody, Req } from '@nestjs/common';
+import { Body, Controller, Post, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { BillingService } from './billing.service';
-import { ApiBody, ApiConsumes } from '@nestjs/swagger';
+import { ApiBody } from '@nestjs/swagger';
 import { CreateCheckoutSessionDto } from './dto/create-checkout-session.dto';
-import Stripe from 'stripe';
 
 @Controller('billing')
 export class BillingController {
@@ -19,18 +19,9 @@ export class BillingController {
   }
 
   @Post('webhooks/stripe')
-  @RawBody() // wichtig: kein JSON-Parsing für Webhook!
-  handleStripeWebhook(@Req() req: Request) {
-    const event = this.stripe.webhooks.constructEvent(
-      req.body,
-      req.headers['stripe-signature'],
-      process.env.STRIPE_WEBHOOK_SECRET
-    );
-
-    switch (event.type) {
-      case 'checkout.session.completed':
-        // Subscription erfolgreich → Tenant aktivieren
-        break;
-    }
+  async handleStripeWebhook(@Req() req: Request) {
+    const signature = req.headers['stripe-signature'] as string;
+    await this.billingService.processWebhook(req.body, signature);
+    return { received: true };
   }
 }

--- a/src/billing/billing.service.ts
+++ b/src/billing/billing.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import Stripe from 'stripe';
+import {
+  ModuleName,
+  UserTier,
+  calculateOrderLinkPricing,
+} from './billing.utils';
 
 @Injectable()
 export class BillingService {
@@ -10,6 +15,24 @@ export class BillingService {
       apiVersion: '2025-07-30.basil',
       typescript: true,
     });
+  }
+
+  async processWebhook(payload: Buffer, signature: string) {
+    const secret = process.env.STRIPE_WEBHOOK_SECRET || '';
+    const event = this.stripe.webhooks.constructEvent(payload, signature, secret);
+    await this.handleStripeEvent(event);
+  }
+
+  private async handleStripeEvent(event: Stripe.Event) {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        console.log(`Stripe checkout completed for session ${session.id}`);
+        break;
+      }
+      default:
+        console.log(`Unhandled stripe event ${event.type}`);
+    }
   }
 
   async createCheckoutSession({

--- a/src/billing/billing.utils.ts
+++ b/src/billing/billing.utils.ts
@@ -1,5 +1,5 @@
-type ModuleName = 'INSIGHT' | 'FLOW' | 'ACCESS';
-type UserTier = 'CORE' | 'TEAM' | 'PRO' | 'ENTERPRISE';
+export type ModuleName = 'INSIGHT' | 'FLOW' | 'ACCESS';
+export type UserTier = 'CORE' | 'TEAM' | 'PRO' | 'ENTERPRISE';
 
 const modulePrices: Record<ModuleName, number> = {
   // pro Module
@@ -17,7 +17,7 @@ const userPrices: Record<UserTier, number> = {
 
 const setupFee = 49;
 
-function calculateOrderLinkPricing(
+export function calculateOrderLinkPricing(
   modules: ModuleName[],
   userTier: UserTier
 ): {

--- a/src/billing/dto/create-checkout-session.dto.ts
+++ b/src/billing/dto/create-checkout-session.dto.ts
@@ -1,3 +1,5 @@
+import { ModuleName, UserTier } from '../billing.utils';
+
 export class CreateCheckoutSessionDto {
   modules: ModuleName[];
   userTier: UserTier;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import { NestFactory, Reflector } from '@nestjs/core';
+import express from 'express';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use('/billing/webhooks/stripe', express.raw({ type: 'application/json' }));
 
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.RMQ,


### PR DESCRIPTION
## Summary
- add raw body middleware for Stripe webhooks
- forward raw payload to BillingService
- expect Buffer payload in BillingService

## Testing
- `pnpm lint` *(fails to find ESLint config)*
- `pnpm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_688b584b1ea0832b9647d56267daded4